### PR TITLE
updates to .gitignore and nginx conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 node_modules
+*.log
+*.swp
+.DS_Store
+npm-debug*
+.cache
+.sass-cache

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -23,6 +23,7 @@ http {
 
     listen           <%= ENV['PORT'] %>;
     server_name      <%= ENV['HOST'] || 'localhost' %>;
+    server_tokens    off;
 
     index            index.html;
 


### PR DESCRIPTION
adds a `server_tokens` config var to nginx config to hide server version. 
should address 2 subtask in this CX ticket:
- [CX-1449](https://spreedly.atlassian.net/browse/CX-1449)

  - [SEC-476](https://spreedly.atlassian.net/browse/SEC-476)
     Server Information Exposure through HTTP Header
  - [SEC-483](https://spreedly.atlassian.net/browse/SEC-483)
     Improper Error Handling

[CX-1449]: https://spreedly.atlassian.net/browse/CX-1449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SEC-476]: https://spreedly.atlassian.net/browse/SEC-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SEC-483]: https://spreedly.atlassian.net/browse/SEC-483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ